### PR TITLE
Fix delete_item in contextmenu

### DIFF
--- a/contextmenu_mudschikato.py
+++ b/contextmenu_mudschikato.py
@@ -40,4 +40,20 @@ class DateiListe(QListWidget):
 
     def delete_item(self, item):
         name = item.text()
-        idx = self.row(
+        idx = self.row(item)
+        self.takeItem(idx)
+        log_event(f"Datei gelöscht: {name}", "DateiListe", "INFO")
+
+        def undo():
+            self.insertItem(idx, name)
+            log_event(f"Datei wiederhergestellt (Undo): {name}", "DateiListe", "UNDO")
+
+        self.undo_manager.add(UndoAction(undo, description=f"Datei {name} gelöscht"))
+
+    def show_info(self, item):
+        QMessageBox.information(
+            self,
+            "Datei-Info",
+            f"Name: {item.text()}\nPosition: {self.row(item)}",
+        )
+


### PR DESCRIPTION
## Summary
- finish `delete_item` in `contextmenu_mudschikato.py`
- log file deletion and add undo action
- show item info in a message box

## Testing
- `python3 -m py_compile contextmenu_mudschikato.py`


------
https://chatgpt.com/codex/tasks/task_e_685ff82b835483259d334d4534842e32